### PR TITLE
Switch to using centos 8 stream for the base OS

### DIFF
--- a/docker/kayobe/Dockerfile
+++ b/docker/kayobe/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM centos:8
+FROM quay.io/centos/centos:stream8
 MAINTAINER "Will Szumski" <will@stackhpc.com>
 
 # Unclear at this time if different environments will change


### PR DESCRIPTION
The centos 8 package mirrors have been retired.