### PR TITLE
Allow skipping copy of kayobe-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Use the examples in examples/\* for inspiration.
 
 `KAYOBE_AUTOMATION_PR_AUTH_TOKEN`: (Required when `KAYOBE_AUTOMATION_PR_TYPE` is set) Auth token to use when submitting pull-requests. Typically you need to create a service account and generate a person access token.
 
-`TEMPEST_OPENRC`: openrc file to use when running tempest
+`TEMPEST_OPENRC`: openrc file content to use when running tempest
 
 ## Pipeline scripts
 

--- a/functions
+++ b/functions
@@ -598,7 +598,9 @@ function create_kayobe_environment {
     mkdir -p "$env"/{src/kayobe,src/kayobe-config,venvs/kayobe}
 
     # Ensure we have an unmodified copy of kayobe-config
-    clean_copy "$kayobe_config_source_path" "$env/src/kayobe-config"
+    if [[ $(realpath "$kayobe_config_source_path") != $(realpath "$env/src/kayobe-config") ]]; then
+        clean_copy "$kayobe_config_source_path" "$env/src/kayobe-config"
+    fi
 
     if [ -f "$kayobe_config_source_path/requirements.txt" ]; then
         # Requirements file gets precedence


### PR DESCRIPTION
If kayobe-config is mounted at /stack/kayobe-automation-env/src/kayobe-config, we can avoid copying the configuration into place and instead work in the bind mounted repository. This has the effect that changes made to the configuration will be reflected in the original repository on the host. This may be useful if we want to extract changes without configuring kayobe-automation to create a PR.
