### PR TITLE
Workaround broken rsync package

### DIFF
--- a/docker/kayobe/Dockerfile
+++ b/docker/kayobe/Dockerfile
@@ -32,7 +32,7 @@ RUN dnf update -y --nobest && \
 # Workaround: rsync: --sparse-block=1024: unknown option
 # Hoepfully they have fixed this issue before this old
 # package is removed.
-RUN dnf install rsync-3.1.3-14.el8 && dnf clean all
+RUN dnf install -y rsync-3.1.3-14.el8 && dnf clean all
 
 RUN python3 -m pip install docker six
 

--- a/docker/kayobe/Dockerfile
+++ b/docker/kayobe/Dockerfile
@@ -32,6 +32,7 @@ RUN dnf update -y --nobest && \
 # Workaround: rsync: --sparse-block=1024: unknown option
 # Hoepfully they have fixed this issue before this old
 # package is removed.
+# See: https://bugzilla.redhat.com/show_bug.cgi?id=2043753
 RUN dnf install -y rsync-3.1.3-14.el8 && dnf clean all
 
 RUN python3 -m pip install docker six

--- a/docker/kayobe/Dockerfile
+++ b/docker/kayobe/Dockerfile
@@ -29,6 +29,11 @@ RUN dnf update -y --nobest && \
         diffstat diffutils procps-ng && \
     dnf clean all
 
+# Workaround: rsync: --sparse-block=1024: unknown option
+# Hoepfully they have fixed this issue before this old
+# package is removed.
+RUN dnf install rsync-3.1.3-14.el8 && dnf clean all
+
 RUN python3 -m pip install docker six
 
 ENV KAYOBE_USER=stack


### PR DESCRIPTION
The issue we are seeing is:

```
[root@ac99140be16b /]# /usr/bin/rsync -F --compress --recursive --rsh=/usr/bin/ssh stack@192.168.45.182:/tmp/a /stack/tempest-artifacts
rsync: on remote machine: --sparse-block=1024: unknown option
```

It has been reported here: https://bugzilla.redhat.com/show_bug.cgi?id=2043753 and a fix is being worked on. Obviously this change has a limited lifetime, but the alternative of using `--sparse-block=0`, has issues too. For example, it won't work on rsync versions that lack this patch. The plan is to revert this change once a new version of rsync, that isn't affected by this bug, has been released.