### PR TITLE
Configurable tempest version

### DIFF
--- a/ansible/kayobe-automation-run-tempest.yml
+++ b/ansible/kayobe-automation-run-tempest.yml
@@ -5,7 +5,7 @@
   vars:
     results_path_local: "{{ lookup('env', 'PWD') }}"
     rally_image: 'stackhpc/docker-rally'
-    rally_tag: latest
+    rally_tag: "{{ lookup('env', 'TEMPEST_VERSION') | default('latest') }}"
     rally_image_full: "{{ rally_docker_registry }}/{{ rally_image }}:{{ rally_tag }}"
     rally_no_sensitive_log: true
     # This ensures you get the latest image if the image is updated


### PR DESCRIPTION
Inject optional tempest versioning from `.automation.conf/config.sh` 