### PR TITLE
Fail if GitHub PR creation fails

### DIFF
--- a/functions
+++ b/functions
@@ -360,6 +360,7 @@ function github_pull_request {
         --user "${KAYOBE_AUTOMATION_PR_GITHUB_USER}:${KAYOBE_AUTOMATION_PR_AUTH_TOKEN}" \
         --header "Accept: application/vnd.github.v3+json" \
         --header "Content-Type: application/json" \
+        --fail \
         --data "${body}" | jq "."
 
     log_info "Pull request created sucessfully"


### PR DESCRIPTION
GitHub pull request creation can fail for various reasons [1], and
should return a 4XX code if it does.

Previously the response code was ignored (the default behaviour of
curl), so PR creation could silently fail. This change adds the curl
--fail argument, as is used for Gitlab.

[1] https://docs.github.com/en/free-pro-team@latest/rest/pulls/pulls?apiVersion=2022-11-28#create-a-pull-request--status-codes
