### PR TITLE
Optionally allow SKC checkout to persist

### DIFF
--- a/functions
+++ b/functions
@@ -595,11 +595,14 @@ function install_kayobe_venv {
 function create_kayobe_environment {
     local env=$1
     local kayobe_config_source_path=${2:-$KAYOBE_CONFIG_SOURCE_PATH}
+    local allow_unclean_kayobe_config=${KAYOBE_AUTOMATION_ALLOW_UNCLEAN_KAYOBE_CONFIG:-0}
     mkdir -p "$env"/{src/kayobe,src/kayobe-config,venvs/kayobe}
 
-    # Ensure we have an unmodified copy of kayobe-config
-    if [[ $(realpath "$kayobe_config_source_path") != $(realpath "$env/src/kayobe-config") ]]; then
-        clean_copy "$kayobe_config_source_path" "$env/src/kayobe-config"
+    if [ "$allow_unclean_kayobe_config" != 0 ]; then
+        # Ensure we have an unmodified copy of kayobe-config
+        if [[ $(realpath "$kayobe_config_source_path") != $(realpath "$env/src/kayobe-config") ]]; then
+            clean_copy "$kayobe_config_source_path" "$env/src/kayobe-config"
+        fi
     fi
 
     if [ -f "$kayobe_config_source_path/requirements.txt" ]; then


### PR DESCRIPTION
Adds a flag to allow the current copy of kayobe-config to be used, rather than copying in a clean version.

This is useful if you want to use previously-generated Kolla config under kayobe-config/etc/kolla