### PR TITLE
feat: add `iproute` for Rocky Linux 9

### DIFF
--- a/docker/kayobe/Dockerfile
+++ b/docker/kayobe/Dockerfile
@@ -39,7 +39,7 @@ RUN dnf install epel-release -y && \
         diffstat diffutils debootstrap procps-ng gdisk util-linux \
         dosfstools lvm2 kpartx systemd-udev bash-completion && \
     if [ "$(grep "^PRETTY_NAME=\"Rocky Linux 9" /etc/os-release)" ] ; then \
-    dnf install -y rsync python3 python3-pip ; else \
+    dnf install -y rsync python3 python3-pip iproute ; else \
     dnf install -y python3-virtualenv rsync-3.1.3-14.el8 ; fi && \
     dnf clean all
 


### PR DESCRIPTION
During Ansible playbook runs `ansible_facts` doesn't get populated unless this package is installed.