### PR TITLE
feat: add support for exceptions to annotations

### DIFF
--- a/utils/kayobe-automation-redact
+++ b/utils/kayobe-automation-redact
@@ -10,13 +10,13 @@ annotation_exceptions = {
 }
 
 def annotate(ctx, value):
-  if not isinstance(value, str):
-    return value
-  path_str = map(str, ctx['path'])
-  if path_str in annotation_exceptions:
-    return f"{'.'.join(annotation_exceptions['prometheus_bcrypt_salt'])}.{value}"
-  else:
-    return f"{'.'.join(path_str)}.{ value }"
+    if not isinstance(value, str):
+      return value
+    path_str = ctx['path'][0]
+    if path_str in annotation_exceptions:
+      return f"{annotation_exceptions[path_str]}.{value}"
+    else:
+      return f"{path_str}.{value}"
 
 def redact_int(ctx, x):
     # For numbers we can't indicate change with a string, so use sentinal values

--- a/utils/kayobe-automation-redact
+++ b/utils/kayobe-automation-redact
@@ -5,11 +5,18 @@ import hashlib
 import base64
 import sys
 
+annotation_exceptions = {
+    'prometheus_bcrypt_salt': 'prometheusbcryptsalt'
+}
+
 def annotate(ctx, value):
   if not isinstance(value, str):
     return value
   path_str = map(str, ctx['path'])
-  return f"{'.'.join(path_str)}.{ value }"
+  if path_str in annotation_exceptions:
+    return f"{'.'.join(annotation_exceptions['prometheus_bcrypt_salt'])}.{value}"
+  else:
+    return f"{'.'.join(path_str)}.{ value }"
 
 def redact_int(ctx, x):
     # For numbers we can't indicate change with a string, so use sentinal values

--- a/utils/kayobe-automation-redact
+++ b/utils/kayobe-automation-redact
@@ -6,17 +6,22 @@ import base64
 import sys
 
 annotation_exceptions = {
-    'prometheus_bcrypt_salt': 'prometheusbcryptsalt'
+    'prometheus_bcrypt_salt': {'original': 'prometheusbcryptsalt.o', 'changed': 'prometheusbcryptsalt.c'},
 }
+
 
 def annotate(ctx, value):
     if not isinstance(value, str):
-      return value
-    path_str = ctx['path'][0]
-    if path_str in annotation_exceptions:
-      return f"{annotation_exceptions[path_str]}.{value}"
+        return value
+    path_str = *map(str, ctx['path']),
+    if path_str[0] in annotation_exceptions:
+        if isinstance(annotation_exceptions[path_str[0]], str):
+            return annotation_exceptions[path_str[0]]
+        else:
+            return annotation_exceptions[path_str[0]][value]
     else:
-      return f"{path_str}.{value}"
+        return f"{'_'.join(path_str)}.{value}"
+
 
 def redact_int(ctx, x):
     # For numbers we can't indicate change with a string, so use sentinal values


### PR DESCRIPTION
Some secrets when redacted are rejected due to invalid characters. One example of this would `prometheus_bcrypt_salt` which is rejected due to the use of underscores. Therefore the solution is to add support for exceptions to the standard annotation format.

See: https://github.com/ansible/ansible/blob/devel/lib/ansible/utils/encrypt.py#L118C46-L118C46
https://github.com/openstack/kolla-ansible/blob/master/ansible/roles/prometheus/templates/prometheus-web.yml.j2#L3