### PR TITLE
feat: Add `KAYOBE_AUTOMATION_SSH_PRIVATE_KEY_NAME`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Use the examples in examples/\* for inspiration.
 
 `KAYOBE_AUTOMATION_SSH_PRIVATE_KEY`: Private key used to login to kayobe managed hosts
 
+`KAYOBE_AUTOMATION_SSH_PRIVATE_KEY_NAME` Name of private key used to login to kayobe managed hosts. Defaults to id_rsa.
+
 `KAYOBE_AUTOMATION_LOG_LEVEL`: Verbosity of logging. Choose one of: `debug`, `info`, `warn`, `error`
 
 `KAYOBE_VAULT_PASSWORD`: Kayobe vault password.

--- a/functions
+++ b/functions
@@ -131,6 +131,9 @@ function config_defaults {
     # to set it in config.sh
     export KAYOBE_AUTOMATION_SSH_PRIVATE_KEY=${KAYOBE_AUTOMATION_SSH_PRIVATE_KEY:-}
 
+    # Name of the SSH key to be used when connecting to kayobe hosts.
+    export KAYOBE_AUTOMATION_SSH_PRIVATE_KEY_NAME=${KAYOBE_AUTOMATION_SSH_PRIVATE_KEY_NAME:-id_rsa}
+
     # TODO: validate/auto detect?
     # Determines which helper to use: gitlab, github, etc, defaults to none.
     export KAYOBE_AUTOMATION_PR_TYPE=${KAYOBE_AUTOMATION_PR_TYPE:-}
@@ -551,10 +554,10 @@ function setup_ssh_agent {
 function inject_ssh_keys {
     # These are read when generating kolla passwords
     if [ ! -z ${KAYOBE_AUTOMATION_SSH_PRIVATE_KEY:+x} ]; then
-        echo "${KAYOBE_AUTOMATION_SSH_PRIVATE_KEY}" >~/.ssh/id_rsa
-        chmod 600 ~/.ssh/id_rsa
-        ssh-keygen -y -f ~/.ssh/id_rsa >~/.ssh/id_rsa.pub
-        chmod 600 ~/.ssh/id_rsa.pub
+        echo "${KAYOBE_AUTOMATION_SSH_PRIVATE_KEY}" >"~/.ssh/${KAYOBE_AUTOMATION_SSH_PRIVATE_KEY_NAME}"
+        chmod 600 "~/.ssh/${KAYOBE_AUTOMATION_SSH_PRIVATE_KEY_NAME}"
+        ssh-keygen -y -f "~/.ssh/${KAYOBE_AUTOMATION_SSH_PRIVATE_KEY_NAME}" >"~/.ssh/${KAYOBE_AUTOMATION_SSH_PRIVATE_KEY_NAME}.pub"
+        chmod 600 "~/.ssh/${KAYOBE_AUTOMATION_SSH_PRIVATE_KEY_NAME}.pub"
     fi
 }
 


### PR DESCRIPTION
The variable `KAYOBE_AUTOMATION_SSH_PRIVATE_KEY_NAME` allows for alternative key names to be used instead of the hardcoded `id_rsa.`

Note: It defaults to `id_rsa` to prevent any breaking changes.