### PR TITLE
Add support for specifying a CA certificate for Rally/Tempest

### DIFF
--- a/ansible/kayobe-automation-run-tempest.yml
+++ b/ansible/kayobe-automation-run-tempest.yml
@@ -5,7 +5,7 @@
   vars:
     results_path_local: "{{ lookup('env', 'PWD') }}"
     rally_image: 'stackhpc/docker-rally'
-    rally_tag: v1.4-dev
+    rally_tag: v1.5.0
     rally_image_full: "{{ rally_docker_registry }}/{{ rally_image }}:{{ rally_tag }}"
     rally_no_sensitive_log: true
     # This ensures you get the latest image if the image is updated

--- a/ansible/kayobe-automation-run-tempest.yml
+++ b/ansible/kayobe-automation-run-tempest.yml
@@ -26,6 +26,13 @@
           suffix: rally-results
         register: results_path_remote
 
+      - name: Create temporary CA certificate directory
+        ansible.builtin.tempfile:
+          state: directory
+          suffix: rally-cacert
+        register: cacert_path_remote
+        when: tempest_cacert is defined
+
       - name: Ensure docker user has permissions to write to results directory
         file:
           path: "{{ results_path_remote.path }}"
@@ -80,6 +87,15 @@
         become: true
         when: tempest_accounts_path is defined
 
+      - name: Copy tempest CA certificate to remote host
+        copy:
+          src: "{{ tempest_cacert }}"
+          dest: "{{ cacert_path_remote.path }}/"
+          owner: "65500"
+          group: "1000"
+        become: true
+        when: tempest_cacert is defined
+
       - name: Run tempest
         command: |-
            docker run --rm --entrypoint=/usr/bin/rally-verify-wrapper.sh
@@ -100,6 +116,9 @@
            {% endif -%}
            {% if tempest_accounts_path is defined -%}
            -v {{ accounts_path_remote }}:/home/rally/tempest-accounts:ro
+           {% endif -%}
+           {% if tempest_cacert is defined -%}
+           -v {{ cacert_path_remote.path }}:/usr/local/share/ca-certificates:ro
            {% endif -%}
            --network host
            {{ rally_image_full }}
@@ -148,3 +167,9 @@
             path: "{{ results_path_remote.path }}"
             state: absent
           when: results_path_remote.path is defined
+
+        - name: cleanup CA certificate
+          file:
+            path: "{{ cacert_path_remote.path }}"
+            state: absent
+          when: cacert_path_remote.path is defined


### PR DESCRIPTION
The tempest_cacert variable may specify the CA certificate path.

Depends on https://github.com/stackhpc/docker-rally/pull/16