### PR TITLE
Use Rocky Linux 8 container base image by default 

### DIFF
--- a/docker/kayobe/Dockerfile
+++ b/docker/kayobe/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1.2
 
 # NOTE: Currently supported images:
-# quay.io/centos/centos:stream8
+# quay.io/rockylinux/rockylinux:8
 # rockylinux:9
-ARG BASE_IMAGE="quay.io/centos/centos:stream8"
+ARG BASE_IMAGE="quay.io/rockylinux/rockylinux:8"
 FROM ${BASE_IMAGE}
 LABEL maintainer="Will Szumski will@stackhpc.com"
 
@@ -27,10 +27,10 @@ ENV container docker
 
 # CMD ["/usr/sbin/init"]
 
-ARG BASE_IMAGE="quay.io/centos/centos:stream8"
+ARG BASE_IMAGE="quay.io/rockylinux/rockylinux:8"
 RUN dnf install epel-release -y && \
     dnf update -y --nobest && \
-    dnf install -y gcc git vim python3-pyyaml \
+    dnf install -y gcc git vim python3-pyyaml findutils\
         libffi-devel sudo which openssh-server e2fsprogs \
         diffstat diffutils debootstrap procps-ng gdisk util-linux \
         dosfstools lvm2 kpartx systemd-udev bash-completion rsync && \


### PR DESCRIPTION
The default build options can no longer generate a working container.

Centos 8 Stream EOL was 31.05.24 - per https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/
The centos:stream8 image has the default URL for repos, which are deprecated.
Archived packages are available in the vault repository. There will be no further package builds.
Rather than update the repos to use an archival vault, let's switch to a base that is consistent but still actively maintained.

This gives additional time until for migration until Rocky Linux 9 as default https://github.com/stackhpc/kayobe-automation/pull/50. 

Note that the rockylinux:8 image does not include xargs by default. This is used in the build process. xargs is provided by the findutils package which has been added to the image.