### PR TITLE
enable CentOS 8 stream vault repos

### DIFF
--- a/docker/kayobe/Dockerfile
+++ b/docker/kayobe/Dockerfile
@@ -18,6 +18,10 @@ ENV container docker
 
 # CMD ["/usr/sbin/init"]
 
+RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' \
+        -e 's/^#baseurl/baseurl/g' \
+        -e 's/mirror\.centos\.org/vault.centos.org/g' /etc/yum.repos.d/CentOS-Stream-*.repo
+
 RUN dnf update -y && \
     dnf install -y gcc git vim python3-pyyaml python3-virtualenv libffi-devel sudo which openssh-server \
         diffstat diffutils && \


### PR DESCRIPTION
Now CentOS8 stream has been EoL'd, the repos aren't available any more.   This updates the Docker container to use the vault repos instead