### PR TITLE
fix: use correct path when normalising files

### DIFF
--- a/scripts/config-diff.sh
+++ b/scripts/config-diff.sh
@@ -251,20 +251,20 @@ function main {
     clean_copy "$KAYOBE_CONFIG_SOURCE_PATH" "$source_kayobe_config_dir"
     clean_copy "$KAYOBE_CONFIG_SOURCE_PATH" "$target_kayobe_config_dir"
 
-    function normalize_file_text() {
+    function normalise_file_text() {
         local file="$1"
         local text="$2"
 
         sed -i "s#/tmp/$text/\(.*\)#/tmp/\1#g" "$file"
     }
 
-    function normalize_files_in_folder() {
+    function normalise_files_in_folder() {
         local folder="$1"
         local text="$2"
 
         # Find all files in the folder and its subfolders and loop through them
         find "$folder" -type f -print0 | while IFS= read -r -d '' file; do
-            normalize_file_text "$file" "$text"
+            normalise_file_text "$file" "$text"
         done
     }
 
@@ -278,7 +278,7 @@ function main {
         redact_config_dir "$target_environment_path"
         encrypt_config_dir "$target_environment_path"
         generate_config "$target_environment_path" "$target_dir"
-        normalize_files_in_folder "$target_environment_path" "target-kayobe-env"
+        normalise_files_in_folder "$target_dir" "target-kayobe-env"
     }
 
     function generate_source_config {
@@ -293,7 +293,7 @@ function main {
         redact_config_dir "$source_environment_path" "$target_kayobe_config_dir"
         encrypt_config_dir "$source_environment_path"
         generate_config "$source_environment_path" "$source_dir"
-        normalize_files_in_folder "$source_environment_path" "source-kayobe-env"
+        normalise_files_in_folder "$source_dir" "source-kayobe-env"
     }
 
     generate_target_config $1 >/dev/null 2>&1 &


### PR DESCRIPTION
Due to a previous addition of adding support for parallel configuration generation when producing a config-diff there is an unfortunate side effect whereby some files such as fluentd contain the different paths they were produced from. This causes false positives in config-diff.

The change had included a fix however the wrong folder to search was specified.
