### PR TITLE
Include internal Kayobe roles/collections in PATHs

### DIFF
--- a/docker/kayobe/Dockerfile
+++ b/docker/kayobe/Dockerfile
@@ -93,5 +93,5 @@ RUN --mount=type=ssh,uid=1000 --mount=type=tmpfs,target=/tmp/src --mount=type=bi
 # Symlinking to /src would create a link within the empty directory
 RUN sudo rmdir /src || true
 
-ENV ANSIBLE_ROLES_PATH="/stack/.ansible/kayobe-automation-roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles"
-ENV ANSIBLE_COLLECTIONS_PATH="/stack/.ansible/kayobe-automation-collections:~/.ansible/collections:/usr/share/ansible/collections"
+ENV ANSIBLE_ROLES_PATH="/stack/.ansible/kayobe-automation-roles:/stack/kayobe-automation-env/src/kayobe/ansible/roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles"
+ENV ANSIBLE_COLLECTIONS_PATH="/stack/.ansible/kayobe-automation-collections:/stack/kayobe-automation-env/src/kayobe/ansible/collections:~/.ansible/collections:/usr/share/ansible/collections"


### PR DESCRIPTION
Allows us to use these roles in hooks, e.g. pre host configures

Fixing an issue where a pre-host-configure hook was unable to use the grubcmdline role:

ERROR! the role 'stackhpc.linux.grubcmdline' was not found in /stack/kayobe-automation-env/src/kayobe-config/etc/kayobe/ansible/roles:/stack/.ansible/kayobe-automation-roles:/stack/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:/stack/kayobe-automation-env/src/kayobe-config/etc/kayobe/ansible
