### PR TITLE
fix!: remove extra argument from redact_config_dir call

### DIFF
--- a/scripts/config-diff.sh
+++ b/scripts/config-diff.sh
@@ -290,7 +290,7 @@ function main {
         merge "$source_kayobe_config_dir" $1
         find_redacted_files "$source_kayobe_config_dir/etc/kayobe"
         create_kayobe_environment "$source_environment_path" "$source_kayobe_config_dir"
-        redact_config_dir "$source_environment_path" "$target_kayobe_config_dir"
+        redact_config_dir "$source_environment_path"
         encrypt_config_dir "$source_environment_path"
         generate_config "$source_environment_path" "$source_dir"
         normalise_files_in_folder "$source_dir" "source-kayobe-env"


### PR DESCRIPTION
~~Encountered an issue whereby config-diff was reporting changes to various files not replaced to the PR in question. Changes included vaulted files like Ceph keyrings but also contents of passwords.yml like rabbitmq-key.~~

~~The change proposed was `d41d8cd98f00b204e9800998ecf8427e` across various files which is the MD5 of an empty string.~~

~~The problem is not consistent and doesn't occur very often and when it does the files it impacts varries each time.~~

~~An unproven theory is that due to the combination of parallel config, automatic secret discovery and the incorrect extra argument `$target_kayobe_config_dir` in redact_config_dir call means that sometimes it MD5 files that don't exist due to https://github.com/stackhpc/kayobe-automation/blob/main/scripts/config-diff.sh#L120~~

The above problem hasn't been fixed with this PR. MD5 hash of empty files are still happening.

Regardless this extra argument is unwanted and should be removed.