### PR TITLE
fix!: store vaulted file hash in temporary variable

### DIFF
--- a/scripts/config-diff.sh
+++ b/scripts/config-diff.sh
@@ -130,7 +130,8 @@ function redact_config_dir {
     for item in "${KAYOBE_CONFIG_VAULTED_FILES_PATHS[@]}"; do
         # skip if file doesn't exist
         if [ -f "$1/src/kayobe-config/$item" ]; then
-            md5sum "$1/src/kayobe-config/$item" | cut -d " " -f 1 >"$1/src/kayobe-config/$item"
+            item_hash=$(md5sum "$1/src/kayobe-config/$item")
+            echo $item_hash | awk '{ print $1;}' >"$1/src/kayobe-config/$item"
         fi
     done
 }


### PR DESCRIPTION
Due to the use of `| .. >` it is possible for the command on the right to run before the left. This can cause situations whereby `md5sum` attempts to hash what is an empty file as `>` operator will clear the file before writing.