### PR TITLE
fix: install `python3-libselinux` to avoid exception

### DIFF
--- a/docker/kayobe/Dockerfile
+++ b/docker/kayobe/Dockerfile
@@ -33,7 +33,8 @@ RUN dnf install epel-release -y && \
     dnf install -y gcc git vim python3-pyyaml findutils\
         libffi-devel sudo which openssh-server e2fsprogs \
         diffstat diffutils debootstrap procps-ng gdisk util-linux \
-        dosfstools lvm2 kpartx systemd-udev bash-completion rsync && \
+        dosfstools lvm2 kpartx systemd-udev bash-completion rsync \
+        python3-libselinux && \
     if [ "$(grep "^PRETTY_NAME=\"Rocky Linux 9" /etc/os-release)" ] ; then \
     dnf install -y python3 python3-pip iproute ; else \
     dnf install -y python3-virtualenv ; fi && \


### PR DESCRIPTION
Noticed within some deployments and [CI](https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/11945760874/) testing it appears that the building the image fails due to missing selinux python bindings.

```
71.87 Exception: Failed to detect selinux python bindings at ['/usr/local/lib64/python3.9/site-packages', '/usr/local/lib/python3.9/site-packages', '/usr/lib64/python3.9/site-packages', '/usr/lib/python3.9/site-packages']
71.90 Failed to install Ansible roles from /stack/kayobe-automation-env/venvs/kayobe/share/kayobe/requirements.yml via Ansible Galaxy: returncode 1
71.92 Control host bootstrap failed - likely Ansible Galaxy flakiness. Retrying
71.92 [Call Trace]
```

This can be resolved by installing `python3-libselinux`