### PR TITLE
(feat) Add proxy support to Tempest container

### DIFF
--- a/ansible/kayobe-automation-run-tempest.yml
+++ b/ansible/kayobe-automation-run-tempest.yml
@@ -139,6 +139,15 @@
            --env TEMPEST_CONF_OVERRIDES="$TEMPEST_CONF_OVERRIDES"
            --env TEMPEST_NO_PROXY_EXTRA
            --env RALLY_CONF_ENABLE_CREATE_TEMPEST_RESOURCES
+           {% if lookup('env', 'TEMPEST_HTTP_PROXY') %}
+           --env HTTP_PROXY="$TEMPEST_HTTP_PROXY"
+           {% endif %}
+           {% if lookup('env', 'TEMPEST_HTTPS_PROXY') %}
+           --env HTTPS_PROXY="$TEMPEST_HTTPS_PROXY"
+           {% endif %}
+           {% if lookup('env', 'TEMPEST_NO_PROXY') %}
+           --env NO_PROXY="$TEMPEST_NO_PROXY"
+           {% endif %}
            {% if tempest_load_list_path is defined -%}
            -v {{ load_list_path_remote }}:/home/rally/tempest-load-list:rw
            {% endif -%}
@@ -162,6 +171,9 @@
           TEMPEST_OPENRC: "{{ lookup('env', 'TEMPEST_OPENRC') }}"
           TEMPEST_CONF_OVERRIDES: "{{ lookup('env', 'TEMPEST_CONF_OVERRIDES') }}"
           TEMPEST_NO_PROXY_EXTRA: "{{ lookup('env', 'TEMPEST_NO_PROXY_EXTRA') }}"
+          TEMPEST_NO_PROXY: "{{ lookup('env', 'TEMPEST_NO_PROXY') }}"
+          TEMPEST_HTTP_PROXY: "{{ lookup('env', 'TEMPEST_HTTP_PROXY') }}"
+          TEMPEST_HTTPS_PROXY: "{{ lookup('env', 'TEMPEST_HTTPS_PROXY') }}"
           RALLY_CONF_ENABLE_CREATE_TEMPEST_RESOURCES: "{{ lookup('env', 'RALLY_CONF_ENABLE_CREATE_TEMPEST_RESOURCES') }}"
         no_log: "{{ rally_no_sensitive_log }}"
         register: docker_result


### PR DESCRIPTION
Add support for HTTP, HTTPS, and NO_PROXY environment variables in the Tempest container. This allows the container to work properly in environments that require proxy configuration for network access.

The following proxy-related environment variables are now supported:
- TEMPEST_HTTP_PROXY
- TEMPEST_HTTPS_PROXY
- TEMPEST_NO_PROXY Variables are configurable in kayobe-config .automtion.conf/config.sh

Variables are configurable in kayobe-config .automtion.conf/config.sh