### PR TITLE
Update docker-rally to v2.1.0

### DIFF
--- a/ansible/kayobe-automation-run-tempest.yml
+++ b/ansible/kayobe-automation-run-tempest.yml
@@ -5,7 +5,7 @@
   vars:
     results_path_local: "{{ lookup('env', 'PWD') }}"
     rally_image: 'stackhpc/docker-rally'
-    rally_tag: v2.0.1
+    rally_tag: v2.1.0
     rally_image_full: "{{ rally_docker_registry }}/{{ rally_image }}:{{ rally_tag }}"
     rally_no_sensitive_log: true
     # This ensures you get the latest image if the image is updated


### PR DESCRIPTION
Use the multi-architecture Rally image with increased Tempest flavor memory. [1]

[1] https://github.com/stackhpc/docker-rally/releases/tag/v2.1.0

tested here - https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/26522113313