### PR TITLE
Do not generate config during control host bootstrap

### DIFF
--- a/docker/kayobe/Dockerfile
+++ b/docker/kayobe/Dockerfile
@@ -123,7 +123,7 @@ RUN --mount=type=ssh,uid=1000 --mount=type=tmpfs,target=/tmp/src --mount=type=bi
     sudo chown -Rf stack:stack /tmp/src && \
     # Strip the secrets so that we don't need to pass in a vault-password
     grep -lR "\$ANSIBLE_VAULT" /tmp/src | xargs rm -f && \
-    bash /tmp/src/.automation/utils/kayobe-automation-install && \
+    bash KAYOBE_BOOTSTRAP_EXTRA_ARGS="--skip-tags kayobe-generate-config" /tmp/src/.automation/utils/kayobe-automation-install && \
     (rm -f /stack/.ssh/{id_rsa,id_rsa.pub} || true) && \
     mkdir -p /stack/.ansible && \
     (cp -rfp /stack/kayobe-automation-env/src/kayobe-config/etc/kayobe/ansible/roles /stack/.ansible/kayobe-automation-roles || true) && \


### PR DESCRIPTION
There was a change in behavior in 2026.1 where we generate kolla config during control host bootstrap.  We do not need to do this in the image build since we never run kolla-ansible.